### PR TITLE
Demo of roxy tools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,12 +21,19 @@ Suggests:
     httr,
     knitr,
     shinytest,
-    testthat (>= 2.0)
+    testthat (>= 2.0),
+    roxytypes,
+    roxylint
+Remotes:
+    roxytypes=github::dgkf/roxytypes,
+    roxylint=github::dgkf/roxylint,
+Config/Needs/documentation:
+    roxytypes,
+    roxylint
 VignetteBuilder:
     knitr
 biocViews:
 Encoding: UTF-8
 Language: en-US
 LazyData: true
-Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,8 @@ Suggests:
     roxytypes,
     roxylint
 Remotes:
-    dgkf/roxytypes,
-    dgkf/roxylint,
+    openpharma/roxytypes,
+    openpharma/roxylint,
 Config/Needs/documentation:
     roxytypes,
     roxylint

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,8 @@ Suggests:
     roxytypes,
     roxylint
 Remotes:
-    roxytypes=github::dgkf/roxytypes,
-    roxylint=github::dgkf/roxylint,
+    dgkf/roxytypes,
+    dgkf/roxylint,
 Config/Needs/documentation:
     roxytypes,
     roxylint

--- a/R/generate_data.R
+++ b/R/generate_data.R
@@ -5,21 +5,26 @@
 #' hazard for the competing event of death, and the hazard for the "soft" competing events.
 #' Censoring is uniform in the given range.
 #'
-#' @param n (`count`)\cr number of patients.
-#' @param cens (`numeric`)\cr minimum and maximum censoring time.
-#' @param haz_ae (`number`)\cr constant hazard for AE.
-#' @param haz_death (`number`)\cr constant hazard for death.
-#' @param haz_soft (`number`)\cr constant hazard for soft competing event.
+#' @typed n: count
+#'   number of patients.
+#' @typed cens: numeric
+#'   minimum and maximum censoring time.
+#' @typed haz_ae: number
+#'   constant hazard for AE.
+#' @typed haz_death: number
+#'   constant hazard for death.
+#' @typed haz_soft: number
+#'   constant hazard for soft competing event.
 #'
-#' @return A `data.frame` with the following columns:
-#'
-#' - `id`: Patient ID.
-#' - `time_to_event`: Time to the first AE, death or soft competing event.
-#' - `type_of_event`: 0 for censored, 1 for AE, 2 for death, 3 for soft competing event.
-#' - `cens`: Censoring time.
+#' @typedreturn data.frame
+#'   a `data.frame` with the following columns:
+#'   - `id`: Patient ID.
+#'   - `time_to_event`: Time to the first AE, death or soft competing event.
+#'   - `type_of_event`: 0 for censored, 1 for AE, 2 for death, 3 for soft
+#'     competing event.
+#'   - `cens`: Censoring time.
 #'
 #' @export
-#'
 #' @examples
 #' set.seed(123)
 #' generate_data(n = 5, cens = c(2, 5), haz_ae = 2, haz_death = 3, haz_soft = 5)

--- a/R/hello.R
+++ b/R/hello.R
@@ -48,7 +48,7 @@ shiny_app <- function() {
 #' @description Greet a person and appropriately capitalize their name
 #'              as a Plumber API.
 #'
-#' @param ... Additional arguments to plumber::pr_run()
+#' @param ... Additional arguments to plumber::pr_run().
 #'
 #' @return Plumber API showcasing the personal greeting feature.
 #' @export

--- a/R/hello.R
+++ b/R/hello.R
@@ -2,11 +2,13 @@
 #'
 #' @description Greet a person and appropriately capitalize their name.
 #'
-#' @param name Your name (character string; e.g. "john doe").
+#' @typed name: string
+#'   a name, such as "john doe".
 #'
-#' @return A character string, capitalized to title case.
+#' @typedreturn string
+#'   capitalized to title case.
+#'
 #' @export
-#'
 #' @examples
 #' hello("james bond")
 hello <- function(name = "your name") {

--- a/R/inc_prop.R
+++ b/R/inc_prop.R
@@ -1,21 +1,30 @@
 #' Computing the Incidence Proportion
 #'
-#' @param data (`data.frame`)\cr with columns including
-#'  - `time_to_event`: Time to the first AE, death or soft competing event.
-#'  - `type_of_event`: 0 for censored, 1 for AE, 2 for death, 3 for soft competing event.
+#' @typed data: data.frame
+#'   with columns including:
+#'   - `time_to_event`: Time to the first AE, death or soft competing
+#'     event.
+#'   - `type_of_event`: 0 for censored, 1 for AE, 2 for death, 3 for soft
+#'     competing event.
+#' @typed tau: numeric
+#'   milestone at which incidence proportion is computed.
 #'
-#' @param tau (`numeric`)\cr milestone at which incidence proportion is computed.
-#'
-#' @return A `vector` with the following entries:
-#'
-#' - `ae_prob`: Estimated probability of AE.
-#' - `ae_prob_var`: Variance of that estimate.
+#' @typedreturn vector
+#'   a vector with the following entries:
+#'   - `ae_prob`: Estimated probability of AE.
+#'   - `ae_prob_var`: Variance of that estimate.
 #'
 #' @export
-#'
 #' @examples
 #' set.seed(123)
-#' dat <- generate_data(n = 5, cens = c(2, 5), haz_ae = 2, haz_death = 3, haz_soft = 5)
+#' dat <- generate_data(
+#'   n = 5,
+#'   cens = c(2, 5),
+#'   haz_ae = 2,
+#'   haz_death = 3,
+#'   haz_soft = 5
+#' )
+#'
 #' inc_prop(dat, tau = 4)
 #'
 inc_prop <- function(data,

--- a/R/inc_prop.R
+++ b/R/inc_prop.R
@@ -10,7 +10,7 @@
 #'   milestone at which incidence proportion is computed.
 #'
 #' @typedreturn vector
-#'   a vector with the following entries:
+#'   with the following entries:
 #'   - `ae_prob`: Estimated probability of AE.
 #'   - `ae_prob_var`: Variance of that estimate.
 #'

--- a/man/generate_data.Rd
+++ b/man/generate_data.Rd
@@ -7,22 +7,23 @@
 generate_data(n, cens, haz_ae, haz_death, haz_soft)
 }
 \arguments{
-\item{n}{(\code{count})\cr number of patients.}
+\item{n}{(`count`)\cr number of patients.}
 
-\item{cens}{(\code{numeric})\cr minimum and maximum censoring time.}
+\item{cens}{(`numeric`)\cr minimum and maximum censoring time.}
 
-\item{haz_ae}{(\code{number})\cr constant hazard for AE.}
+\item{haz_ae}{(`number`)\cr constant hazard for AE.}
 
-\item{haz_death}{(\code{number})\cr constant hazard for death.}
+\item{haz_death}{(`number`)\cr constant hazard for death.}
 
-\item{haz_soft}{(\code{number})\cr constant hazard for soft competing event.}
+\item{haz_soft}{(`number`)\cr constant hazard for soft competing event.}
 }
 \value{
-A \code{data.frame} with the following columns:
+(`data.frame`)\cr a \code{data.frame} with the following columns:
 \itemize{
 \item \code{id}: Patient ID.
 \item \code{time_to_event}: Time to the first AE, death or soft competing event.
-\item \code{type_of_event}: 0 for censored, 1 for AE, 2 for death, 3 for soft competing event.
+\item \code{type_of_event}: 0 for censored, 1 for AE, 2 for death, 3 for soft
+competing event.
 \item \code{cens}: Censoring time.
 }
 }

--- a/man/generate_data.Rd
+++ b/man/generate_data.Rd
@@ -7,18 +7,18 @@
 generate_data(n, cens, haz_ae, haz_death, haz_soft)
 }
 \arguments{
-\item{n}{(`count`)\cr number of patients.}
+\item{n}{(\code{count})\cr number of patients.}
 
-\item{cens}{(`numeric`)\cr minimum and maximum censoring time.}
+\item{cens}{(\code{numeric})\cr minimum and maximum censoring time.}
 
-\item{haz_ae}{(`number`)\cr constant hazard for AE.}
+\item{haz_ae}{(\code{number})\cr constant hazard for AE.}
 
-\item{haz_death}{(`number`)\cr constant hazard for death.}
+\item{haz_death}{(\code{number})\cr constant hazard for death.}
 
-\item{haz_soft}{(`number`)\cr constant hazard for soft competing event.}
+\item{haz_soft}{(\code{number})\cr constant hazard for soft competing event.}
 }
 \value{
-(`data.frame`)\cr a \code{data.frame} with the following columns:
+(\code{data.frame})\cr a \code{data.frame} with the following columns:
 \itemize{
 \item \code{id}: Patient ID.
 \item \code{time_to_event}: Time to the first AE, death or soft competing event.

--- a/man/hello.Rd
+++ b/man/hello.Rd
@@ -7,10 +7,10 @@
 hello(name = "your name")
 }
 \arguments{
-\item{name}{(`string`)\cr a name, such as "john doe".}
+\item{name}{(\code{string})\cr a name, such as "john doe".}
 }
 \value{
-(`string`)\cr capitalized to title case.
+(\code{string})\cr capitalized to title case.
 }
 \description{
 Greet a person and appropriately capitalize their name.

--- a/man/hello.Rd
+++ b/man/hello.Rd
@@ -7,10 +7,10 @@
 hello(name = "your name")
 }
 \arguments{
-\item{name}{Your name (character string; e.g. "john doe").}
+\item{name}{(`string`)\cr a name, such as "john doe".}
 }
 \value{
-A character string, capitalized to title case.
+(`string`)\cr capitalized to title case.
 }
 \description{
 Greet a person and appropriately capitalize their name.

--- a/man/inc_prop.Rd
+++ b/man/inc_prop.Rd
@@ -7,16 +7,18 @@
 inc_prop(data, tau)
 }
 \arguments{
-\item{data}{(\code{data.frame})\cr with columns including
+\item{data}{(`data.frame`)\cr with columns including:
 \itemize{
-\item \code{time_to_event}: Time to the first AE, death or soft competing event.
-\item \code{type_of_event}: 0 for censored, 1 for AE, 2 for death, 3 for soft competing event.
+\item \code{time_to_event}: Time to the first AE, death or soft competing
+event.
+\item \code{type_of_event}: 0 for censored, 1 for AE, 2 for death, 3 for soft
+competing event.
 }}
 
-\item{tau}{(\code{numeric})\cr milestone at which incidence proportion is computed.}
+\item{tau}{(`numeric`)\cr milestone at which incidence proportion is computed.}
 }
 \value{
-A \code{vector} with the following entries:
+(`vector`)\cr a vector with the following entries:
 \itemize{
 \item \code{ae_prob}: Estimated probability of AE.
 \item \code{ae_prob_var}: Variance of that estimate.
@@ -27,7 +29,14 @@ Computing the Incidence Proportion
 }
 \examples{
 set.seed(123)
-dat <- generate_data(n = 5, cens = c(2, 5), haz_ae = 2, haz_death = 3, haz_soft = 5)
+dat <- generate_data(
+  n = 5,
+  cens = c(2, 5),
+  haz_ae = 2,
+  haz_death = 3,
+  haz_soft = 5
+)
+
 inc_prop(dat, tau = 4)
 
 }

--- a/man/inc_prop.Rd
+++ b/man/inc_prop.Rd
@@ -18,7 +18,7 @@ competing event.
 \item{tau}{(\code{numeric})\cr milestone at which incidence proportion is computed.}
 }
 \value{
-(\code{vector})\cr a vector with the following entries:
+(\code{vector})\cr with the following entries:
 \itemize{
 \item \code{ae_prob}: Estimated probability of AE.
 \item \code{ae_prob_var}: Variance of that estimate.

--- a/man/inc_prop.Rd
+++ b/man/inc_prop.Rd
@@ -7,7 +7,7 @@
 inc_prop(data, tau)
 }
 \arguments{
-\item{data}{(`data.frame`)\cr with columns including:
+\item{data}{(\code{data.frame})\cr with columns including:
 \itemize{
 \item \code{time_to_event}: Time to the first AE, death or soft competing
 event.
@@ -15,10 +15,10 @@ event.
 competing event.
 }}
 
-\item{tau}{(`numeric`)\cr milestone at which incidence proportion is computed.}
+\item{tau}{(\code{numeric})\cr milestone at which incidence proportion is computed.}
 }
 \value{
-(`vector`)\cr a vector with the following entries:
+(\code{vector})\cr a vector with the following entries:
 \itemize{
 \item \code{ae_prob}: Estimated probability of AE.
 \item \code{ae_prob_var}: Variance of that estimate.

--- a/man/plumber_api.Rd
+++ b/man/plumber_api.Rd
@@ -7,7 +7,7 @@
 plumber_api(...)
 }
 \arguments{
-\item{...}{Additional arguments to plumber::pr_run()}
+\item{...}{Additional arguments to plumber::pr_run().}
 }
 \value{
 Plumber API showcasing the personal greeting feature.

--- a/man/roxygen/meta.R
+++ b/man/roxygen/meta.R
@@ -1,0 +1,12 @@
+list(
+  markdown = TRUE,
+  packages = c(
+    "roxylint",
+    "roxytypes"
+    ),
+  roclets = c(
+    "namespace",
+    "rd",
+    "roxylint::roxylint"
+  )
+)

--- a/man/roxygen/meta.R
+++ b/man/roxygen/meta.R
@@ -3,7 +3,7 @@ list(
   packages = c(
     "roxylint",
     "roxytypes"
-    ),
+  ),
   roclets = c(
     "namespace",
     "rd",

--- a/man/roxylint/meta.R
+++ b/man/roxylint/meta.R
@@ -3,7 +3,7 @@ list(
     typed = list(
       "descriptions should start lowercase" = "^[^[:upper:]]",
       roxylint::lint_full_stop,
-      NULL  # disallow registration of package defaults
+      NULL # disallow registration of package defaults
     ),
     param = list(
       "descriptions should start lowercase" = "^[^[:upper:]]",

--- a/man/roxylint/meta.R
+++ b/man/roxylint/meta.R
@@ -1,0 +1,13 @@
+list(
+  linters = list(
+    typed = list(
+      "descriptions should start lowercase" = "^[^[:upper:]]",
+      roxylint::lint_full_stop,
+      NULL  # disallow registration of package defaults
+    ),
+    param = list(
+      "descriptions should start lowercase" = "^[^[:upper:]]",
+      roxylint::lint_full_stop
+    )
+  )
+)

--- a/man/roxytypes/meta.R
+++ b/man/roxytypes/meta.R
@@ -1,0 +1,5 @@
+list(
+  format = function(x, name, type, default, description, ...) {
+    glue::glue("(`{type}`)\\cr {description}")
+  }
+)


### PR DESCRIPTION
@danielinteractive and I have been toying with the idea of building some supporting tools for linting documentation and we thought this package might serve as a good testing ground. 

This PR is primarily as a demo. Happy to gather feedback and iterate if anything can be improved. Even if this is out-of-scope for `savvyr`, this PR can still serve as a discussion of using these tools in practice and closed without merging.

I'll add notes in-line below, but just want to call out a few features where I'd especially appreciate feedback:

- Added tags included `@typed`, `@typedreturn` (this feels too verbose to me)
- `roxytypes` has support for a `@default` "tag" (it's not really a roxygen2 tag, just part of the `@typed` parsing). I'm still debating whether there's a better way to provide this feature.
- `roxylints` defaults follow the `tidyverse` style guide, but `openpharma` deviates in a few places so those styles are customized in `man/roxylints/meta.R`.